### PR TITLE
Support of IN operator

### DIFF
--- a/copper-server-api/src/main/java/com/pogeyan/cmis/api/uri/expression/MethodOperator.java
+++ b/copper-server-api/src/main/java/com/pogeyan/cmis/api/uri/expression/MethodOperator.java
@@ -19,36 +19,36 @@
 package com.pogeyan.cmis.api.uri.expression;
 
 /**
- * Enumerations for all supported methods of the ODATA expression parser
- * for ODATA version 2.0 (with some restrictions).
+ * Enumerations for all supported methods of the ODATA expression parser for
+ * ODATA version 2.0 (with some restrictions).
  * 
  */
 public enum MethodOperator {
-  ENDSWITH("endswith"), INDEXOF("indexof"), STARTSWITH("startswith"), CONTAINS("contains"), EXISTS("exists"), TOLOWER("tolower"), TOUPPER("toupper"), TRIM(
-      "trim"), SUBSTRING("substring"), SUBSTRINGOF("substringof"), CONCAT("concat"), LENGTH("length"), YEAR("year"),
-  MONTH("month"), DAY("day"), HOUR("hour"), MINUTE("minute"), SECOND("second"), ROUND("round"), FLOOR("floor"),
-  CEILING("ceiling");
+	ENDSWITH("endswith"), INDEXOF("indexof"), STARTSWITH("startswith"), CONTAINS("contains"), EXISTS("exists"),
+	IN("in"), TOLOWER("tolower"), TOUPPER("toupper"), TRIM("trim"), SUBSTRING("substring"), SUBSTRINGOF("substringof"),
+	CONCAT("concat"), LENGTH("length"), YEAR("year"), MONTH("month"), DAY("day"), HOUR("hour"), MINUTE("minute"),
+	SECOND("second"), ROUND("round"), FLOOR("floor"), CEILING("ceiling");
 
-  private String syntax;
-  private String stringRespresentation;
+	private String syntax;
+	private String stringRespresentation;
 
-  private MethodOperator(final String syntax) {
-    this.syntax = syntax;
-    stringRespresentation = syntax;
-  }
+	private MethodOperator(final String syntax) {
+		this.syntax = syntax;
+		stringRespresentation = syntax;
+	}
 
-  /**
-   * @return Operators name for usage in in text
-   */
-  @Override
-  public String toString() {
-    return stringRespresentation;
-  }
+	/**
+	 * @return Operators name for usage in in text
+	 */
+	@Override
+	public String toString() {
+		return stringRespresentation;
+	}
 
-  /**
-   * @return URI literal of the unary operator as used in the URL.
-   */
-  public String toUriLiteral() {
-    return syntax;
-  }
+	/**
+	 * @return URI literal of the unary operator as used in the URL.
+	 */
+	public String toUriLiteral() {
+		return syntax;
+	}
 }

--- a/copper-server-impl/src/main/java/com/pogeyan/cmis/impl/uri/expression/FilterParserImpl.java
+++ b/copper-server-impl/src/main/java/com/pogeyan/cmis/impl/uri/expression/FilterParserImpl.java
@@ -528,6 +528,8 @@ public class FilterParserImpl implements FilterParser {
 		lAvailableMethods.put(MethodOperator.INDEXOF.toUriLiteral(), new InfoMethod(MethodOperator.INDEXOF, 2, 2));
 		
 		lAvailableMethods.put(MethodOperator.EXISTS.toUriLiteral(), new InfoMethod(MethodOperator.EXISTS, 2, 2));
+		
+		lAvailableMethods.put(MethodOperator.IN.toUriLiteral(), new InfoMethod(MethodOperator.IN, 2, 2));
 
 		lAvailableMethods.put(MethodOperator.STARTSWITH.toUriLiteral(),
 				new InfoMethod(MethodOperator.STARTSWITH, 2, 2));

--- a/copper-server-mongo/src/main/java/com/pogeyan/cmis/data/mongo/MongoExpressionVisitor.java
+++ b/copper-server-mongo/src/main/java/com/pogeyan/cmis/data/mongo/MongoExpressionVisitor.java
@@ -1,6 +1,7 @@
 package com.pogeyan.cmis.data.mongo;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -250,7 +251,9 @@ public class MongoExpressionVisitor<T> implements ExpressionVisitor {
 			} else {
 				return this.query.criteria(getQueryName(fieldOperand.getUriLiteral())).doesNotExist();
 			}
-
+		case IN:
+			return this.query.criteria(getQueryName(fieldOperand.getUriLiteral()))
+					.in(Arrays.asList(fieldValue.trim().split(" ")));
 		case STARTSWITH:
 			Pattern sw_pattern = Pattern.compile("^" + fieldValue, Pattern.CASE_INSENSITIVE);
 			return this.query.filter(getQueryName(fieldOperand.getUriLiteral()), sw_pattern);


### PR DESCRIPTION
Usage: 
    var query = { filter: "*,cmis:objectTypeId eq tck:testid_with_properties and in (cmis:objectId::'5d96f488c1f50133c8e5338b 5d96f488c1f50133c8e5338e 5d96f488c1f50133c8e5338d')" };
Supports for only String property types
